### PR TITLE
24 change implementation of getrolesaddresses

### DIFF
--- a/contracts/Community.sol
+++ b/contracts/Community.sol
@@ -431,37 +431,7 @@ contract Community is CommunityStorage, ICommunity {
     ///////////////////////////////////////////////////////////
     /// public (view)section
     ///////////////////////////////////////////////////////////
-    /**
-     * @notice Returns all addresses belong to Role
-     * @custom:shortd all addresses belong to Role
-     * @param rolesIndex role index
-     * @return array of address 
-     */
-    function getAddresses(
-        uint8 rolesIndex
-    ) 
-        public 
-        view
-        returns(address[] memory)
-    {
-        uint8[] memory rolesIndexes = new uint8[](1);
-        rolesIndexes[0] = rolesIndex;
-
-        return abi.decode(
-            _functionDelegateCallView(
-                address(implCommunityView), 
-                abi.encodeWithSelector(
-                    CommunityView.getAddresses.selector,
-                    rolesIndexes
-                ), 
-                ""
-            ), 
-            (address[])
-        );  
-
-    }
-    
-
+ 
     /**
      * @dev can be duplicate items in output. see https://github.com/Intercoin/CommunityContract/issues/4#issuecomment-1049797389
      * @notice Returns all addresses belong to Role
@@ -470,11 +440,11 @@ contract Community is CommunityStorage, ICommunity {
      * @return array of address 
      */
     function getAddresses(
-        uint8[] memory rolesIndexes
+        uint8[] calldata rolesIndexes
     ) 
         public 
         view
-        returns(address[] memory)
+        returns(uint256[][] memory)
     {
         return abi.decode(
             _functionDelegateCallView(
@@ -485,42 +455,10 @@ contract Community is CommunityStorage, ICommunity {
                 ), 
                 ""
             ), 
-            (address[])
+            (uint256[][])
         );  
 
     }
-    
-    /**
-     * @notice Returns all roles which member belong to
-     * @custom:shortd member's roles
-     * @param member member's address
-     * @return array of roles 
-     */
-    function getRoles(
-        address member
-    ) 
-        public 
-        view
-        returns(uint8[] memory)
-    {
-        address[] memory members = new address[](1);
-        members[0] = member;
-
-        return abi.decode(
-            _functionDelegateCallView(
-                address(implCommunityView), 
-                abi.encodeWithSelector(
-                    //CommunityView.getRoles().selector,
-                    bytes4(keccak256("getRoles(address[])")),
-                    members
-                ), 
-                ""
-            ), 
-            (uint8[])
-        );  
-
-    }
-
     
     /**
      * @dev can be duplicate items in output. see https://github.com/Intercoin/CommunityContract/issues/4#issuecomment-1049797389
@@ -534,7 +472,7 @@ contract Community is CommunityStorage, ICommunity {
     ) 
         public 
         view
-        returns(uint8[] memory)
+        returns(uint256[][] memory)
     {
         return abi.decode(
             _functionDelegateCallView(
@@ -546,7 +484,7 @@ contract Community is CommunityStorage, ICommunity {
                 ), 
                 ""
             ), 
-            (uint8[])
+            (uint256[][])
         );  
 
     }

--- a/contracts/CommunityView.sol
+++ b/contracts/CommunityView.sol
@@ -82,49 +82,36 @@ contract CommunityView is CommunityStorage {
         }
         
     }
+    
+    
 
     ///////////////////////////////////////////////////////////
     /// public  section
     ///////////////////////////////////////////////////////////
     /**
-     * @dev can be duplicate items in output. see https://github.com/Intercoin/CommunityContract/issues/4#issuecomment-1049797389
+     * @dev since user will be in several roles then addresses in output can be duplicated.
      * @notice Returns all addresses belong to Role
      * @custom:shortd all addresses belong to Role
      * @param rolesIndexes array of roles indexes
-     * @return array of address 
+     * @return array of array addresses ([uint256][uint160(address)])
      */
-    function getAddresses(
-        uint8[] memory rolesIndexes
-    ) 
-        public 
-        view
-        returns(address[] memory)
-    {
-        address[] memory l;
+    function getAddresses(uint8[] memory rolesIndexes) public view returns(uint256[][] memory) {
+        uint256[][] memory l;
 
-        if (rolesIndexes.length == 0) {
-            l = new address[](0);
-        } else {
-            uint256 len;
-            for (uint256 j = 0; j < rolesIndexes.length; j++) {
-                len += _rolesByIndex[rolesIndexes[j]].members.length();
-            }
-
-            l = new address[](len);
+        l = new uint256[][](rolesIndexes.length);
+        if (rolesIndexes.length != 0) {
             
-            uint256 ilen;
             uint256 tmplen;
             for (uint256 j = 0; j < rolesIndexes.length; j++) {
                 tmplen = _rolesByIndex[rolesIndexes[j]].members.length();
+                l[j] = new uint256[](tmplen);
                 for (uint256 i = 0; i < tmplen; i++) {
-                    l[ilen] = _rolesByIndex[rolesIndexes[j]].members.at(i);
-                    ilen += 1;
+                    l[j][i] = uint160(_rolesByIndex[rolesIndexes[j]].members.at(i));
                 }
             }
         }
         return l;
     }
-    
     
     /**
      * @dev can be duplicate items in output. see https://github.com/Intercoin/CommunityContract/issues/4#issuecomment-1049797389
@@ -133,40 +120,25 @@ contract CommunityView is CommunityStorage {
      * @param accounts account's addresses
      * @return l array of roles 
      */
-    function getRoles(
-        address[] memory accounts
-    ) 
-        public 
-        view
-        returns(uint8[] memory)
-    {
-        uint8[] memory l;
+    function getRoles(address[] memory accounts) public view returns(uint256[][] memory) {
+        uint256[][] memory l;
 
-        uint256 len;
-        uint256 tmplen;
-
+        l = new uint256[][](accounts.length);
+        if (accounts.length != 0) {
+        
+            uint256 tmplen;
             for (uint256 j = 0; j < accounts.length; j++) {
                 tmplen = _rolesByMember[accounts[j]].length();
-                len += tmplen;
-            }
+                l[j] = new uint256[](tmplen);
+                for (uint256 i = 0; i < tmplen; i++) {
+                    l[j][i] = _rolesByMember[accounts[j]].get(i);
 
-            l = new uint8[](len);
-            
-            uint256 ilen;
-            for (uint256 j = 0; j < accounts.length; j++) {
-                uint256 i;
-
-                tmplen = _rolesByMember[accounts[j]].length();
-
-                for (i = 0; i < tmplen; i++) {
-                    l[ilen] = _rolesByMember[accounts[j]].get(i);
-                    ilen += 1;
                 }
             }
-
+        }
         return l;
     }
-  
+    
     /**
      * @dev can be duplicate items in output. see https://github.com/Intercoin/CommunityContract/issues/4#issuecomment-1049797389
      * @notice if call without params then returns all existing roles 

--- a/contracts/interfaces/ICommunity.sol
+++ b/contracts/interfaces/ICommunity.sol
@@ -13,6 +13,6 @@ interface ICommunity {
     ) external;
     
     function addressesCount(uint8 roleIndex) external view returns(uint256);
-    function getRoles(address member)external view returns(uint8[] memory);
-    function getAddresses(uint8 rolesIndex) external view returns(address[] memory);
+    function getRoles(address[] calldata accounts)external view returns(uint256[][] memory);
+    function getAddresses(uint8[] calldata rolesIndexes) external view returns(uint256[][] memory);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artman325/community",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Smart contract for managing community membership and roles",
   "main": "index.js",
   "files": [

--- a/test/test.js
+++ b/test/test.js
@@ -519,8 +519,8 @@ describe("Community", function () {
 
         it("creator must be owner", async () => {
             
-            var rolesList = (await CommunityInstance.connect(owner)["getRoles(address)"](owner.address));
-            expect(rolesList.includes(rolesIndex.get('owners'))).to.be.eq(true); // outside OWNERS role
+            var rolesList = (await CommunityInstance.connect(owner)["getRoles(address[])"]([owner.address]));
+            expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('owners'))).to.be.eq(true); // outside OWNERS role
 
         });
 
@@ -594,10 +594,10 @@ describe("Community", function () {
             expect(allMembersCount).to.be.eq(EIGHT); // accounts - One,Two,Three,Four,Five,Six,Seven and OWNER
 
             let allMembersInRole1 = await CommunityInstance.connect(owner)["getAddresses(uint8[])"]([rolesIndex.get('role1')]);
-            expect(allMembersInRole1.length).to.be.eq(FIVE); // accounts - Two,Three,Four,Five,Six
+            expect(allMembersInRole1[0].length).to.be.eq(FIVE); // accounts - Two,Three,Four,Five,Six
 
-            let allMembersInRole2 = await CommunityInstance.connect(owner)["getAddresses(uint8)"](rolesIndex.get('role2'));
-            expect(allMembersInRole2.length).to.be.eq(THREE); // accounts - Five,Six,Seven
+            let allMembersInRole2 = await CommunityInstance.connect(owner)["getAddresses(uint8[])"]([rolesIndex.get('role2')]);
+            expect(allMembersInRole2[0].length).to.be.eq(THREE); // accounts - Five,Six,Seven
 
 
         }); 
@@ -712,6 +712,7 @@ describe("Community", function () {
             ], "Sender can not revoke role '" +rolesTitle.get('role2')+"'");
 
         }); 
+
         it("can remove account from role", async () => {
 
             var rolesList;
@@ -724,8 +725,8 @@ describe("Community", function () {
             ]);
             
             // check that accountTwo got `get('role1')`
-            rolesList = (await CommunityInstance.connect(owner)["getRoles(address)"](accountTwo.address));
-            expect(rolesList.includes(rolesIndex.get('role1'))).to.be.eq(true); // 'outside role'
+            rolesList = (await CommunityInstance.connect(owner)["getRoles(address[])"]([accountTwo.address]));
+            expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role1'))).to.be.eq(true); // 'outside role'
             
             await mixedCall(CommunityInstance, trustedForwardMode, accountThree, 'revokeRoles(address[],uint8[])', [
                 [accountTwo.address], [rolesIndex.get('role1')]
@@ -737,8 +738,8 @@ describe("Community", function () {
             ]);
 
             // check removing
-            rolesList = (await CommunityInstance.connect(owner)["getRoles(address)"](accountTwo.address));
-            expect(rolesList.includes(rolesIndex.get('role1'))).to.be.eq(false); // 'outside role'
+            rolesList = (await CommunityInstance.connect(owner)["getRoles(address[])"]([accountTwo.address]));
+            expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role1'))).to.be.eq(false); // 'outside role'
             
         });
 
@@ -785,8 +786,8 @@ describe("Community", function () {
             ]);
             
             // check
-            rolesList = await CommunityInstance.connect(owner)["getRoles(address)"](accountTwo.address);
-            expect(rolesList.includes(rolesIndex.get('role2'))).to.be.eq(true); 
+            rolesList = await CommunityInstance.connect(owner)["getRoles(address[])"]([accountTwo.address]);
+            expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role2'))).to.be.eq(true); 
             
             // check via isAccountHasRole
             expect(await CommunityInstance.connect(owner).isAccountHasRole(accountTwo.address, rolesIndex.get('role2'))).to.be.eq(true);
@@ -813,8 +814,8 @@ describe("Community", function () {
             ]);
             
             // check again
-            rolesList = await CommunityInstance.connect(owner)["getRoles(address)"](accountTwo.address);
-            expect(rolesList.includes(rolesIndex.get('role2'))).to.be.eq(false); 
+            rolesList = await CommunityInstance.connect(owner)["getRoles(address[])"]([accountTwo.address]);
+            expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role2'))).to.be.eq(false); 
 
             // check via isAccountHasRole
             expect(await CommunityInstance.connect(owner).isAccountHasRole(accountTwo.address, rolesIndex.get('role2'))).to.be.eq(false);
@@ -829,9 +830,9 @@ describe("Community", function () {
                 [accountFive.address], [rolesIndex.get('role1')]
             ]);
             
-            var rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address)"](accountFive.address));
+            var rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address[])"]([accountFive.address]));
 
-            expect(rolesList.length).to.be.eq(ZERO);
+            expect(rolesList[0].map(x => x.toNumber()).length).to.be.eq(ZERO);
 
         });
 
@@ -856,8 +857,8 @@ describe("Community", function () {
             
             var rolesList;
 
-            rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address)"](accountFive.address));
-            expect(rolesList.length).to.be.eq(ZERO);
+            rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address[])"]([accountFive.address]));
+            expect(rolesList[0].map(x => x.toNumber()).length).to.be.eq(ZERO);
             await mixedCall(CommunityInstance, trustedForwardMode, owner, 'grantRoles(address[],uint8[])', [
                 [accountFive.address], 
                 [rolesIndex.get('role1'),rolesIndex.get('role2')]
@@ -871,8 +872,8 @@ describe("Community", function () {
                 [rolesIndex.get('role5'),rolesIndex.get('role6')]
             ]);
 
-            rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address)"](accountFive.address));
-            expect(rolesList.length).to.be.eq(SIX); // role#1,role#2,role#3,role#4,role#5,role#6
+            rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address[])"]([accountFive.address]));
+            expect(rolesList[0].map(x => x.toNumber()).length).to.be.eq(SIX); // role#1,role#2,role#3,role#4,role#5,role#6
 
             await mixedCall(CommunityInstance, trustedForwardMode, owner, 'revokeRoles(address[],uint8[])', [
                 [accountFive.address], 
@@ -887,8 +888,8 @@ describe("Community", function () {
                 [rolesIndex.get('role4'),rolesIndex.get('role5')]
             ]);
 
-            rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address)"](accountFive.address));
-            expect(rolesList.length).to.be.eq(ZERO); 
+            rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address[])"]([accountFive.address]));
+            expect(rolesList[0].map(x => x.toNumber()).length).to.be.eq(ZERO); 
         });
 
         describe("test using params as array", function () {
@@ -941,47 +942,47 @@ describe("Community", function () {
                 ///// checking by Members
                 var rolesList;
                 // owner
-                rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address)"](owner.address));
-                expect(rolesList.includes(rolesIndex.get('role1'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role2'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role3'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role4'))).to.be.eq(false); 
+                rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address[])"]([owner.address]));
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role1'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role2'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role3'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role4'))).to.be.eq(false); 
                 // accountTwo
-                rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address)"](accountTwo.address));
-                expect(rolesList.includes(rolesIndex.get('role1'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role2'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role3'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role4'))).to.be.eq(false); 
+                rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address[])"]([accountTwo.address]));
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role1'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role2'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role3'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role4'))).to.be.eq(false); 
                 // accountThree
-                rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address)"](accountThree.address));
-                expect(rolesList.includes(rolesIndex.get('role1'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role2'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role3'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role4'))).to.be.eq(false); 
+                rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address[])"]([accountThree.address]));
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role1'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role2'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role3'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role4'))).to.be.eq(false); 
                 // accountFourth
-                rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address)"](accountFourth.address));
-                expect(rolesList.includes(rolesIndex.get('role1'))).to.be.eq(false); 
-                expect(rolesList.includes(rolesIndex.get('role2'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role3'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role4'))).to.be.eq(false); 
+                rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address[])"]([accountFourth.address]));
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role1'))).to.be.eq(false); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role2'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role3'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role4'))).to.be.eq(false); 
                 // accountFive
-                rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address)"](accountFive.address));
-                expect(rolesList.includes(rolesIndex.get('role1'))).to.be.eq(false); 
-                expect(rolesList.includes(rolesIndex.get('role2'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role3'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role4'))).to.be.eq(false); 
+                rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address[])"]([accountFive.address]));
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role1'))).to.be.eq(false); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role2'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role3'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role4'))).to.be.eq(false); 
                 // accountSix
-                rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address)"](accountSix.address));
-                expect(rolesList.includes(rolesIndex.get('role1'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role2'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role3'))).to.be.eq(false); 
-                expect(rolesList.includes(rolesIndex.get('role4'))).to.be.eq(false); 
+                rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address[])"]([accountSix.address]));
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role1'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role2'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role3'))).to.be.eq(false); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role4'))).to.be.eq(false); 
                 // accountSeven
-                rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address)"](accountSeven.address));
-                expect(rolesList.includes(rolesIndex.get('role1'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role2'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role3'))).to.be.eq(false); 
-                expect(rolesList.includes(rolesIndex.get('role4'))).to.be.eq(false); 
+                rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address[])"]([accountSeven.address]));
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role1'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role2'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role3'))).to.be.eq(false); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role4'))).to.be.eq(false); 
 
             });
 
@@ -989,22 +990,22 @@ describe("Community", function () {
                 let rolesList;
 
                 rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address[])"]([accountTwo.address, accountThree.address]));
-                expect(rolesList.includes(rolesIndex.get('role1'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role2'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role3'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role4'))).to.be.eq(false); 
+                expect((rolesList[0].concat(rolesList[1]).map(x => x.toNumber())).includes(rolesIndex.get('role1'))).to.be.eq(true); 
+                expect((rolesList[0].concat(rolesList[1]).map(x => x.toNumber())).includes(rolesIndex.get('role2'))).to.be.eq(true); 
+                expect((rolesList[0].concat(rolesList[1]).map(x => x.toNumber())).includes(rolesIndex.get('role3'))).to.be.eq(true); 
+                expect((rolesList[0].concat(rolesList[1]).map(x => x.toNumber())).includes(rolesIndex.get('role4'))).to.be.eq(false); 
 
                 // 6
-                expect(rolesList.length).to.be.eq(6);
+                expect(rolesList[0].concat(rolesList[1]).length).to.be.eq(6);
                 
                 rolesList = (await CommunityInstance.connect(accountTen)["getRoles(address[])"]([accountThree.address, accountFive.address]));
-                expect(rolesList.includes(rolesIndex.get('role1'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role2'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role3'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role4'))).to.be.eq(false); 
+                expect((rolesList[0].concat(rolesList[1]).map(x => x.toNumber())).includes(rolesIndex.get('role1'))).to.be.eq(true); 
+                expect((rolesList[0].concat(rolesList[1]).map(x => x.toNumber())).includes(rolesIndex.get('role2'))).to.be.eq(true); 
+                expect((rolesList[0].concat(rolesList[1]).map(x => x.toNumber())).includes(rolesIndex.get('role3'))).to.be.eq(true); 
+                expect((rolesList[0].concat(rolesList[1]).map(x => x.toNumber())).includes(rolesIndex.get('role4'))).to.be.eq(false); 
 
                 // 5
-                expect(rolesList.length).to.be.eq(5);
+                expect(rolesList[0].concat(rolesList[1]).length).to.be.eq(5);
             });
 
             it("check addressesCount(uint8)", async () => {
@@ -1172,9 +1173,9 @@ describe("Community", function () {
                 await mixedCall(CommunityInstance, trustedForwardMode, relayer, 'inviteAccept(string,bytes,string,bytes)', [adminMsg, sSig, recipientMsg, rSig]);
                 
                 // check roles of accountTwo
-                rolesList = await CommunityInstance.connect(owner)["getRoles(address)"](accountTwo.address);
-                expect(rolesList.includes(rolesIndex.get('role1'))).to.be.eq(false); 
-                expect(rolesList.includes(rolesIndex.get('role2'))).to.be.eq(true); 
+                rolesList = await CommunityInstance.connect(owner)["getRoles(address[])"]([accountTwo.address]);
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role1'))).to.be.eq(false); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role2'))).to.be.eq(true); 
 
             }); 
 
@@ -1182,8 +1183,8 @@ describe("Community", function () {
 
                 var rolesList;
             
-                rolesList = (await CommunityInstance.connect(owner)["getRoles(address)"](relayer.address));
-                expect(rolesList.includes(rolesIndex.get('relayers'))).to.be.eq(true); 
+                rolesList = (await CommunityInstance.connect(owner)["getRoles(address[])"]([relayer.address]));
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('relayers'))).to.be.eq(true); 
 
                 
                 // generate messages and signatures
@@ -1224,10 +1225,10 @@ describe("Community", function () {
                 const CommunityInstanceEndingBalance = (await ethers.provider.getBalance(CommunityInstance.address));
                 
                 // check roles of accountTwo
-                rolesList = await CommunityInstance.connect(owner)["getRoles(address)"](accountTwo.address);
-                expect(rolesList.includes(rolesIndex.get('role1'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role2'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role3'))).to.be.eq(true); 
+                rolesList = await CommunityInstance.connect(owner)["getRoles(address[])"]([accountTwo.address]);
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role1'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role2'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role3'))).to.be.eq(true); 
                 
 
                 let rewardAmount = await CommunityInstance.REWARD_AMOUNT();
@@ -1296,10 +1297,10 @@ describe("Community", function () {
                 await expect(await CommunityInstance.invitedBy(accountTwo.address)).not.to.be.eq(accountNine.address); //'store wrong keys in invited mapping'
 
                 // check roles of accountTwo
-                rolesList = await CommunityInstance.connect(owner)["getRoles(address)"](accountTwo.address);
-                expect(rolesList.includes(rolesIndex.get('role1'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role2'))).to.be.eq(true); 
-                expect(rolesList.includes(rolesIndex.get('role3'))).to.be.eq(false); 
+                rolesList = await CommunityInstance.connect(owner)["getRoles(address[])"]([accountTwo.address]);
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role1'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role2'))).to.be.eq(true); 
+                expect(rolesList[0].map(x => x.toNumber()).includes(rolesIndex.get('role3'))).to.be.eq(false); 
             });
         });
 


### PR DESCRIPTION
now getRoles and getAddresses return has array as input params and return array of arrays
like this
`function getRoles(address[] calldata accounts)external view returns(uint256[][] memory);`
`function getAddresses(uint8[] calldata rolesIndexes) external view returns(uint256[][] memory);`

Output will be like this
[ [1,2,3,4], [2,5], [], [7,8,9]]
and 
[ [0x567... ,0xab4... ,0xfe5... ], [0x123... ,0x456...], [], [0x123...]]
respectively
