### PR TITLE
22 implement ownable interface with different semantics

### DIFF
--- a/contracts/Community.sol
+++ b/contracts/Community.sol
@@ -428,6 +428,51 @@ contract Community is CommunityStorage, ICommunity {
         );
     }
 
+    function transferOwnership(
+        address newOwner
+    ) 
+        public 
+        override
+        onlyOwner 
+    {
+        _functionDelegateCall(
+            address(implCommunityState), 
+            // abi.encodeWithSelector(
+            //     CommunityState.setExtraURI.selector,
+            //     roleIndex, extraURI
+            // )
+            msg.data
+        );
+
+        _accountForOperation(
+            OPERATION_TRANSFEROWNERSHIP << OPERATION_SHIFT_BITS,
+            uint160(_msgSender()),
+            uint160(newOwner)
+        );
+    }
+
+    function renounceOwnership(
+    ) 
+        public 
+        override
+        onlyOwner 
+    {
+        _functionDelegateCall(
+            address(implCommunityState), 
+            // abi.encodeWithSelector(
+            //     CommunityState.setExtraURI.selector,
+            //     roleIndex, extraURI
+            // )
+            msg.data
+        );
+
+        _accountForOperation(
+            OPERATION_RENOUNCEOWNERSHIP << OPERATION_SHIFT_BITS,
+            uint160(_msgSender()),
+            0
+        );
+    }
+
     ///////////////////////////////////////////////////////////
     /// public (view)section
     ///////////////////////////////////////////////////////////

--- a/contracts/Community.sol
+++ b/contracts/Community.sol
@@ -696,7 +696,7 @@ contract Community is CommunityStorage, ICommunity {
         external 
         view 
         override
-        returns (address owner) 
+        returns (address) 
     {
         return abi.decode(
             _functionDelegateCallView(

--- a/contracts/Community.sol
+++ b/contracts/Community.sol
@@ -628,8 +628,7 @@ contract Community is CommunityStorage, ICommunity {
      * @param roleIndex role index
      * @return bool 
      */
-    //function isMemberHasRole(
-    function isAccountHasRole(
+    function hasRole(
         address account, 
         uint8 roleIndex
     ) 
@@ -639,7 +638,6 @@ contract Community is CommunityStorage, ICommunity {
     {
 
         //require(_roles[rolename.stringToBytes32()] != 0, "Such role does not exists");
-
         return _rolesByMember[account].contains(roleIndex);
 
     }

--- a/contracts/CommunityState.sol
+++ b/contracts/CommunityState.sol
@@ -357,8 +357,34 @@ contract CommunityState is CommunityStorage {
     ///////////////////////////////////////////////////////////
     /// internal section
     ///////////////////////////////////////////////////////////
-    
-    
+
+    ///////////////////////////////////
+    // ownable implementation with diff semantic
+    /**
+    * @dev will grantRoles([address], OWNERS_ROLE) and then revokeRoles(msg.caller, OWNERS_ROLE). 
+    * There is no need to have transferRole() function because normally no one can transfer their own roles unilaterally, except owners. 
+    * Instead they manage roles under them.
+    */
+    // The function renounceOwnership() will simply revokeRoles(getAddresses(OWNERS_ROLE), OWNERS_ROLE) from everyone who has it, including the caller. 
+    // This function is irreversible. The contract will be ownerless. The trackers should see the appropriate events/logs as from any Ownable interface.
+    function _transferOwnership(address newOwner) internal override {
+        address sender = _msgSender();
+        if (newOwner == address(0)) {
+            // if newOwner == address(0) it's just renounceOwnership()    
+            // we will simply revokeRoles(getAddresses(OWNERS_ROLE), OWNERS_ROLE) from everyone who has it, including the caller. 
+            EnumerableSetUpgradeable.AddressSet storage ownersList = _rolesByIndex[_roles[DEFAULT_OWNERS_ROLE]].members;
+            for (uint256 i = 0; i < ownersList.length(); i++) {
+                _revokeRole(sender, _roles[DEFAULT_OWNERS_ROLE], ownersList.at(i));
+            }
+            emit RenounceOwnership();
+        } else {
+            _grantRole(_roles[DEFAULT_OWNERS_ROLE], sender, _roles[DEFAULT_OWNERS_ROLE], newOwner);
+            _revokeRole(sender, _roles[DEFAULT_OWNERS_ROLE], sender);
+            emit OwnershipTransferred(sender, newOwner);
+        }
+    }
+
+    ///////////////////////////////////
     /**
     * @dev find which role can grant `targetRoleIndex` to account
     * @param rolesWhichCanGrant array of role indexes which want to grant `targetRoleIndex` to account

--- a/contracts/CommunityState.sol
+++ b/contracts/CommunityState.sol
@@ -373,8 +373,10 @@ contract CommunityState is CommunityStorage {
             // if newOwner == address(0) it's just renounceOwnership()    
             // we will simply revokeRoles(getAddresses(OWNERS_ROLE), OWNERS_ROLE) from everyone who has it, including the caller. 
             EnumerableSetUpgradeable.AddressSet storage ownersList = _rolesByIndex[_roles[DEFAULT_OWNERS_ROLE]].members;
-            for (uint256 i = 0; i < ownersList.length(); i++) {
-                _revokeRole(sender, _roles[DEFAULT_OWNERS_ROLE], ownersList.at(i));
+            uint256 len = ownersList.length();
+            // loop through stack, due to reducing members in role, we just get address from zero position `len` times
+            for (uint256 i = 0; i < len; i++) {
+                _revokeRole(sender, _roles[DEFAULT_OWNERS_ROLE], ownersList.at(0));
             }
             emit RenounceOwnership();
         } else {

--- a/contracts/CommunityStorage.sol
+++ b/contracts/CommunityStorage.sol
@@ -153,6 +153,9 @@ abstract contract CommunityStorage is Initializable, ReentrancyGuardUpgradeable,
     uint8 internal constant OPERATION_INVITE_ACCEPT = 0x7;
     uint8 internal constant OPERATION_SET_ROLE_URI = 0x8;
     uint8 internal constant OPERATION_SET_EXTRA_URI = 0x9;
+    uint8 internal constant OPERATION_TRANSFEROWNERSHIP = 0xa;
+    uint8 internal constant OPERATION_RENOUNCEOWNERSHIP = 0xb;
+    
     
     enum ReimburseStatus{ NONE, PENDING, CLAIMED }
 
@@ -282,23 +285,31 @@ abstract contract CommunityStorage is Initializable, ReentrancyGuardUpgradeable,
         
     }
 
-
-    ///////////////////////////////////
-    // ownable implementation with diff semantic
+    ///////////////////////////////////////////////////
+    // common to use
+    //////////////////////////////////////////////////
     /**
-     * @dev Returns the first address in getAddresses(OWNERS_ROLE)
+     * @dev Returns the first address in getAddresses(OWNERS_ROLE). usually(if not transferownership/renounceownership) it's always will be deployer.
+     * @return address first address on owners role list.
      */
     function owner() public view override returns (address) {
         return _rolesByIndex[_roles[DEFAULT_OWNERS_ROLE]].members.at(0);
     }
 
+    /**
+     * @dev Returns true if account is belong to DEFAULT_OWNERS_ROLE
+     * @param account account address
+     * @return bool 
+     */
     function isOwner(address account) public view returns(bool) {
         //hasRole(address, OWNERS_ROLE)
         return _isTargetInRole(account, _roles[DEFAULT_OWNERS_ROLE]);
     }
-
+    function _isTargetInRole(address target, uint8 targetRoleIndex) internal view returns(bool) {
+        return _rolesByMember[target].contains(targetRoleIndex);
+    }
     /**
-     * @dev Throws if the sender is not the owner.
+     * @dev Throws if the sender is not in the DEFAULT_OWNERS_ROLE.
      */
     function _checkOwner() internal view override {
         require(_isTargetInRole(_msgSender(), _roles[DEFAULT_OWNERS_ROLE]), "Ownable: caller is not the owner");
@@ -307,17 +318,6 @@ abstract contract CommunityStorage is Initializable, ReentrancyGuardUpgradeable,
     function _msgSender() internal view override(ContextUpgradeable, TrustedForwarder) returns (address)  {
         return TrustedForwarder._msgSender();
     }
-
-///////////////////////////////////
-
-
-    ///////////////////////////////////////////////////
-    // common to use
-    //////////////////////////////////////////////////
-    function _isTargetInRole(address target, uint8 targetRoleIndex) internal view returns(bool) {
-        return _rolesByMember[target].contains(targetRoleIndex);
-    }
-    
 
 
     ///////////////////////////////////////////////////

--- a/contracts/CommunityView.sol
+++ b/contracts/CommunityView.sol
@@ -291,30 +291,6 @@ contract CommunityView is CommunityStorage {
     {
         return inviteSignatures[sSig];
     }
-    
-
-    /**
-     * @notice is member has role
-     * @custom:shortd checking is member belong to role
-     * @param account user address
-     * @param rolename role name
-     * @return bool 
-     */
-    //function isMemberHasRole(
-    function isAccountHasRole(
-        address account, 
-        string memory rolename
-    ) 
-        public 
-        view 
-        returns(bool) 
-    {
-
-        //require(_roles[rolename.stringToBytes32()] != 0, "Such role does not exists");
-
-        return _rolesByMember[account].contains(_roles[rolename.stringToBytes32()]);
-
-    }
-
+   
 }
     

--- a/test/test.js
+++ b/test/test.js
@@ -790,8 +790,8 @@ describe("Community", function () {
             rolesList = await CommunityInstance.connect(owner)["getRoles(address[])"]([accountTwo.address]);
             expect(rolesList[0].includes(rolesIndex.get('role2'))).to.be.eq(true); 
             
-            // check via isAccountHasRole
-            expect(await CommunityInstance.connect(owner).isAccountHasRole(accountTwo.address, rolesIndex.get('role2'))).to.be.eq(true);
+            // check via hasRole
+            expect(await CommunityInstance.connect(owner).hasRole(accountTwo.address, rolesIndex.get('role2'))).to.be.eq(true);
             expect(await CommunityInstance.connect(owner).getRoleIndex(rolesTitle.get('role2'))).to.be.eq(rolesIndex.get('role2'));
 
             // account 3
@@ -818,8 +818,8 @@ describe("Community", function () {
             rolesList = await CommunityInstance.connect(owner)["getRoles(address[])"]([accountTwo.address]);
             expect(rolesList[0].includes(rolesIndex.get('role2'))).to.be.eq(false); 
 
-            // check via isAccountHasRole
-            expect(await CommunityInstance.connect(owner).isAccountHasRole(accountTwo.address, rolesIndex.get('role2'))).to.be.eq(false);
+            // check via hasRole
+            expect(await CommunityInstance.connect(owner).hasRole(accountTwo.address, rolesIndex.get('role2'))).to.be.eq(false);
         });
 
         it("check amount of roles after revoke(empty strings)", async () => {


### PR DESCRIPTION
> Please rename isAccountHasRole to hasRole, and all calls in our repos to it
> 
> Implement Ownable interface exactly as OpenZeppelin ABI suggests, but semantics are different:
> 
> owner() returns the first address in getAddresses(OWNERS_ROLE)
> isOwner(address) returns hasRole(address, OWNERS_ROLE)
> transferOwnership(address) will grantRoles([address], OWNERS_ROLE) and then revokeRoles(msg.caller, OWNERS_ROLE). > There is no need to have transferRole() function because normally no one can transfer their own roles unilaterally, except > owners. Instead they manage roles under them.
> The function renounceOwnership() will simply revokeRoles(getAddresses(OWNERS_ROLE), OWNERS_ROLE) from everyone > who has it, including the caller. This function is irreversible. The contract will be ownerless. The trackers should see the appropriate events/logs as from any Ownable interface.

Done